### PR TITLE
Support compiling with OpenWatcom

### DIFF
--- a/c89atomic.h
+++ b/c89atomic.h
@@ -333,11 +333,13 @@ typedef unsigned char           c89atomic_flag;
     #else
         #define C89ATOMIC_INLINE inline __attribute__((always_inline))
     #endif
+#elif defined(__WATCOMC__)
+    #define C89ATOMIC_INLINE _inline
 #else
     #define C89ATOMIC_INLINE
 #endif
 
-#if defined(_MSC_VER) /*&& !defined(__clang__)*/
+#if defined(_MSC_VER) || defined(__WATCOMC__) /*&& !defined(__clang__)*/
     /* Visual C++. */
     #define c89atomic_memory_order_relaxed  0
     #define c89atomic_memory_order_consume  1
@@ -382,8 +384,8 @@ typedef unsigned char           c89atomic_flag;
         }
     #endif  /* C89ATOMIC_X64 */
     #else
-        /* Old Visual C++. */
-        #if defined(__i386) || defined(_M_IX86)
+        /* Old Visual C++ and OpenWatcom. */
+        #if defined(C89ATOMIC_X86)
             /* x86. Implemented via inlined assembly. */
 
             /* thread_fence() */

--- a/tests/c89atomic_basic.c
+++ b/tests/c89atomic_basic.c
@@ -744,10 +744,10 @@ int main(int argc, char** argv)
     c89atomic_test__basic__fetch_and();
 
     /* Putting these functions here for testing that they compile. */
-    c89atomic_is_lock_free_8(NULL);
-    c89atomic_is_lock_free_16(NULL);
-    c89atomic_is_lock_free_32(NULL);
-    c89atomic_is_lock_free_64(NULL);
+    (void)c89atomic_is_lock_free_8(NULL);
+    (void)c89atomic_is_lock_free_16(NULL);
+    (void)c89atomic_is_lock_free_32(NULL);
+    (void)c89atomic_is_lock_free_64(NULL);
     c89atomic_compiler_fence();
     c89atomic_thread_fence(c89atomic_memory_order_seq_cst);
     c89atomic_signal_fence(c89atomic_memory_order_seq_cst);


### PR DESCRIPTION
This currently works with both the test program and MiniAudio, however there are still a number of warnings relating to the inline x86 assembly functions:

```
..\c89atomic.h(410): Warning! W107: Missing return value for function 'c89atomic_exchange_explicit_8'
..\c89atomic.h(420): Warning! W107: Missing return value for function 'c89atomic_exchange_explicit_16'
..\c89atomic.h(430): Warning! W107: Missing return value for function 'c89atomic_exchange_explicit_32'
..\c89atomic.h(442): Warning! W107: Missing return value for function 'c89atomic_fetch_add_explicit_8'
..\c89atomic.h(452): Warning! W107: Missing return value for function 'c89atomic_fetch_add_explicit_16'
..\c89atomic.h(462): Warning! W107: Missing return value for function 'c89atomic_fetch_add_explicit_32'
..\c89atomic.h(474): Warning! W107: Missing return value for function 'c89atomic_compare_and_swap_8'
..\c89atomic.h(484): Warning! W107: Missing return value for function 'c89atomic_compare_and_swap_16'
..\c89atomic.h(494): Warning! W107: Missing return value for function 'c89atomic_compare_and_swap_32'
..\c89atomic.h(506): Warning! W107: Missing return value for function 'c89atomic_compare_and_swap_64'
```
