### PR TITLE
Fixed compilation warning: extension used when using `-std=gnu89`

### DIFF
--- a/c89atomic.h
+++ b/c89atomic.h
@@ -339,7 +339,7 @@ typedef unsigned char           c89atomic_bool;
     command line, we cannot use the "inline" keyword and instead need to use "__inline__". In an attempt to work around this issue
     I am using "__inline__" only when we're compiling in strict ANSI mode.
     */
-    #if defined(__STRICT_ANSI__)
+    #if defined(__STRICT_ANSI__) || !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
         #define C89ATOMIC_INLINE __inline__ __attribute__((always_inline))
     #else
         #define C89ATOMIC_INLINE inline __attribute__((always_inline))


### PR DESCRIPTION
When using `-std=gnu89`, `__STRICT_ANSI__` is not defined. However, we still need to use `__inline__`, since `inline` is not supported by gnu89.

This commit resolves https://github.com/mackron/c89atomic/issues/7.