### PR TITLE
[cmake] Metabuild system script change suggestion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,10 +91,15 @@ endif()
 set(COMMON_LINK_LIBRARIES)
 
 if (UNIX)
-    find_library(LIB_ATOMIC NAMES atomic)
-    if(LIB_ATOMIC)
-        list(APPEND COMMON_LINK_LIBRARIES ${LIB_ATOMIC})
-    endif()
+	# pure
+	if(NOT MINGW AND NOT MSYS AND NOT CYGWIN)
+		find_library(LIB_ATOMIC NAMES atomic)
+		if(LIB_ATOMIC)
+			list(APPEND COMMON_LINK_LIBRARIES ${LIB_ATOMIC})
+		endif()
+	else()
+
+	endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,12 @@ add_library(c89atomic STATIC
     c89atomic.h
 )
 
-target_include_directories(c89atomic PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(
+	c89atomic 
+	INTERFACE
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+	$<INSTALL_INTERFACE:/>
+	)
 target_link_libraries     (c89atomic PRIVATE c89atomic_common)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ add_library(c89atomic STATIC
 
 target_include_directories(
 	c89atomic 
-	INTERFACE
+	PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
 	$<INSTALL_INTERFACE:/>
 	)


### PR DESCRIPTION
## removed library fetching on host UNIX -> target not UNIX.
```cmake
		find_library(LIB_ATOMIC NAMES atomic)
		if(LIB_ATOMIC)
			list(APPEND COMMON_LINK_LIBRARIES ${LIB_ATOMIC})
		endif()
```

This part tries to fetch native library when targetted for MINGW, CGWIN, etc therefore linker panics. Funny.
I have bypassed them by simply not fetching libatomic under these conditions, under assumptions 

## separated build/install interface for smooth installation scenario.
```
target_include_directories(c89atomic PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR})
```
source prefixed including will cause error on installing c89atomic.
separated include directories with build/install interface.